### PR TITLE
fix: copy storage bindings correctly

### DIFF
--- a/.changeset/eighty-carrots-matter.md
+++ b/.changeset/eighty-carrots-matter.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-device-api': patch
+---
+
+Copy storage bindings correctly.

--- a/src/api/utils/hash.ts
+++ b/src/api/utils/hash.ts
@@ -276,9 +276,13 @@ export function bindingsDescriptorCopy(
   const uniformBufferBindings =
     a.uniformBufferBindings &&
     arrayCopy(a.uniformBufferBindings, bufferBindingCopy);
+  const storageBufferBindings =
+    a.storageBufferBindings &&
+    arrayCopy(a.storageBufferBindings, bufferBindingCopy);
   return {
     samplerBindings,
     uniformBufferBindings,
+    storageBufferBindings,
     pipeline: a.pipeline,
   };
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a

-   [ ] New feature
-   [x] Bug fix
-   [ ] Site / Document optimization
-   [ ] TypeScript definition update
-   [ ] Refactoring
-   [ ] Performance improvement
-   [ ] Code style optimization
-   [ ] Test Case
-   [ ] Branch merge
-   [ ] Other (about what?)

### 🔗 Related issue link

`bindingsDescriptorCopy` should copy storage bindings correctly.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

-   [ ] Doc is updated/provided or not needed
-   [ ] Demo is updated/provided or not needed
-   [ ] TypeScript definition is updated/provided or not needed
-   [ ] Changelog is provided or not needed
