### PR TITLE
fix: fixed error when render target and swap chain height don't match

### DIFF
--- a/src/webgpu/RenderPass.ts
+++ b/src/webgpu/RenderPass.ts
@@ -220,7 +220,7 @@ export class RenderPass_WebGPU implements RenderPass {
   }
 
   private flipY(y: number, h: number) {
-    const height = this.device['swapChainHeight'];
+    const height = this.gfxColorAttachment[0].height;
     return height - y - h;
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a

-   [ ] New feature
-   [x] Bug fix
-   [ ] Site / Document optimization
-   [ ] TypeScript definition update
-   [ ] Refactoring
-   [ ] Performance improvement
-   [ ] Code style optimization
-   [ ] Test Case
-   [ ] Branch merge
-   [ ] Other (about what?)

### 🔗 Related issue link
修复 https://github.com/antvis/G/issues/1625
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
下游PickingPlugin使用1x1的大小渲染，flipY使用swapChainHeight计算会导致setViewport验证错误，改成使用gfxColorAttachment的height

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

-   [ ] Doc is updated/provided or not needed
-   [ ] Demo is updated/provided or not needed
-   [ ] TypeScript definition is updated/provided or not needed
-   [ ] Changelog is provided or not needed
